### PR TITLE
[TEST] Added cluster double join conflict unit test

### DIFF
--- a/src/services/cluster.rs
+++ b/src/services/cluster.rs
@@ -614,7 +614,7 @@ pub mod tests {
       status
     );
 
-    // Join
+    // Join success
     let payload = ClusterJoinBody {
       cargo: cargo.name.to_owned(),
       network: network.name.to_owned(),
@@ -628,6 +628,19 @@ pub mod tests {
       cargo.name,
       cluster_name,
       StatusCode::OK,
+      status
+    );
+
+    // Join with conflict
+    let res = join_cargo(&srv, cluster_name, &payload).await?;
+    let status = res.status();
+    assert_eq!(
+      status,
+      StatusCode::CONFLICT,
+      "Expect join cargo with name {} to cluster with name {} to return with status {}, got {}",
+      cargo.name,
+      cluster_name,
+      StatusCode::CONFLICT,
       status
     );
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added cluster double join conflict unit test

**- How I did it**

I added a 2nd join with same params to perform a conflict inside `src/services/cluster.rs`

**- How to verify it**

Run tests

```sh
cargo make test
```

